### PR TITLE
Enhance error detection in getParents function for better development experience

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+## [Unreleased]
+
+### Added
+
+-   Introduced explicit error throwing in the `getParents` function when a widget cannot be located, enhancing the
+    development experience by enabling faster error identification and resolution (PR #<PR_NUMBER>).

--- a/routing/pages/instance.ts
+++ b/routing/pages/instance.ts
@@ -42,13 +42,11 @@ class PageInstance {
 	get parents(): IParents {
 		// Ascending list of containers layouts of the current page
 		const value: IWidgetSpecs[] = [];
-
 		const widget = widgets.get(this.element);
-		if (!widget) {
-			throw new Error(`Widget "${this.element}" not found`);
-		}
-		let { layout } = widget;
 
+		if (!widget) throw new Error(`Widget "${this.element}" not found`);
+
+		let { layout } = widget;
 		while (layout) {
 			const found = [...widgets.values()].find(({ name }) => name === layout);
 			if (!found) {

--- a/routing/pages/instance.ts
+++ b/routing/pages/instance.ts
@@ -1,65 +1,71 @@
-import type {URI} from '@beyond-js/kernel/routing';
-import type {Route} from "../route";
-import {widgets, IWidgetSpecs} from '@beyond-js/widgets/render';
+import type { URI } from '@beyond-js/kernel/routing';
+import type { Route } from '../route';
+import { widgets, IWidgetSpecs } from '@beyond-js/widgets/render';
 
 export interface IParents {
-    error?: string,
-    value?: IWidgetSpecs[]
+	error?: string;
+	value?: IWidgetSpecs[];
 }
 
 let id = 0;
 
 export /*bundle*/
 class PageInstance {
-    readonly #uri: URI;
-    get uri() {
-        return this.#uri;
-    }
+	readonly #uri: URI;
+	get uri() {
+		return this.#uri;
+	}
 
-    readonly #route: Route;
-    get route() {
-        return this.#route;
-    }
+	readonly #route: Route;
+	get route() {
+		return this.#route;
+	}
 
-    get element() {
-        return this.#route.page;
-    }
+	get element() {
+		return this.#route.page;
+	}
 
-    get is(): string {
-        return 'page';
-    }
+	get is(): string {
+		return 'page';
+	}
 
-    readonly #id: number;
-    get id(): string {
-        return `${this.element}:${this.#id}`;
-    }
+	readonly #id: number;
+	get id(): string {
+		return `${this.element}:${this.#id}`;
+	}
 
-    /**
-     * Returns the ascending layouts
-     *
-     * @return {{error?: string, parents?: IWidgetSpecs[]}}
-     */
-    get parents(): IParents {
-        // Ascending list of containers layouts of the current page
-        const value: IWidgetSpecs[] = [];
-        let {layout} = widgets.get(this.element);
-        while (layout) {
-            const found = [...widgets.values()].find(({name}) => name === layout);
-            if (!found) {
-                const error = `Layout "${layout}" not found`;
-                return {error};
-            }
+	/**
+	 * Returns the ascending layouts
+	 *
+	 * @return {{error?: string, parents?: IWidgetSpecs[]}}
+	 */
+	get parents(): IParents {
+		// Ascending list of containers layouts of the current page
+		const value: IWidgetSpecs[] = [];
 
-            value.unshift(found);
-            layout = found.layout;
-        }
+		const widget = widgets.get(this.element);
+		if (!widget) {
+			throw new Error(`Widget "${this.element}" not found`);
+		}
+		let { layout } = widget;
 
-        return {value};
-    }
+		while (layout) {
+			const found = [...widgets.values()].find(({ name }) => name === layout);
+			if (!found) {
+				const error = `Layout "${layout}" not found`;
+				return { error };
+			}
 
-    constructor(uri: URI, route: Route) {
-        this.#uri = uri;
-        this.#route = route;
-        this.#id = ++id;
-    }
+			value.unshift(found);
+			layout = found.layout;
+		}
+
+		return { value };
+	}
+
+	constructor(uri: URI, route: Route) {
+		this.#uri = uri;
+		this.#route = route;
+		this.#id = ++id;
+	}
 }


### PR DESCRIPTION
This pull request enhances error detection within the getParents function to provide developers with immediate and clear feedback when a widget is not found. By throwing a new Error with a descriptive message, this change enables developers to quickly identify and address issues, streamlining the development process and improving the overall developer experience.

Example of current error:
![image](https://github.com/beyondjs/widgets/assets/7352361/23466a4f-d8ac-4c91-bb35-15178110b28a)


Changes:
- Implement throwing of a new Error when `widget` is null or undefined to facilitate rapid error identification.
- Simplified error handling by removing the previous non-throwing error logic for unfound layouts, enforcing a consistent error-handling strategy.

The update is aimed at improving developer productivity by preventing silent failures and ensuring that widget retrieval issues are surfaced promptly.

